### PR TITLE
fix: update reference in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           git switch -C deploy
       - name: Update Version In Checked-Out Code
         run: |
-          sed -i "s@\(.*image:\).*@\1 ghcr.io/${{ env.OWNER_LC }}/lome-dev:${{ github.sha }}@" ${GITHUB_WORKSPACE}/manifests/deployment.yml
+          sed -i "s@\(.*image:\).*@\1 ghcr.io/${{ env.OWNER_LC }}/kneipolympics:${{ github.sha }}@" ${GITHUB_WORKSPACE}/manifests/deployment.yml
       - name: Commit The New Image Reference
         uses: stefanzweifel/git-auto-commit-action@v5
         if: ${{ github.ref_name == 'main' }}


### PR DESCRIPTION
Change the image reference in the GitHub Actions deployment  workflow from 'lome-dev' to 'kneipolympics' to reflect the  correct container image for deployment. This ensures that  the latest version of the application is deployed correctly.