### PR TITLE
fix(ingress): update host for kneipolympics service

### DIFF
--- a/manifests/ingress.yml
+++ b/manifests/ingress.yml
@@ -7,7 +7,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`bar.lome.dev`)
+    - match: Host(`kneipolympics.beer`)
       kind: Rule
       services:
         - name: kneipolympics-service


### PR DESCRIPTION
Change the host in the ingress manifest from `bar.lome.dev` to   `kneipolympics.beer` to reflect the correct domain for the   kneipolympics service. This ensures proper routing of traffic.
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5NGGcWAok`](https://gitbutler.com/h1ghbre4k3r/gitbutler/reviews/5NGGcWAok)

**docs: add new dad joke about a sad cocktail**


Include a new joke in the dad-jokes.md file to expand the
collection and provide more humor for the community section.

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [docs: add new dad joke about a sad cocktail](https://gitbutler.com/h1ghbre4k3r/gitbutler/reviews/5NGGcWAok/commit/1ffc900d-736f-42ef-8e9d-64d4553c4b76) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/h1ghbre4k3r/gitbutler/reviews/5NGGcWAok)_
<!-- GitButler Review Footer Boundary Bottom -->
