### PR TITLE
feat: add Nginx configuration for frontend server

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,3 +27,4 @@ FROM nginx:1.27 as final
 LABEL org.opencontainers.image.source https://github.com/H1ghBre4k3r/kneipolympics
 
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+COPY default.conf /etc/nginx/conf.d/default.conf

--- a/frontend/default.conf
+++ b/frontend/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Introduce a default Nginx configuration file to serve the frontend  application. The configuration listens on port 80, sets the server  name to localhost, and specifies the root directory for static files.  It also handles error pages and ensures that the application can  handle client-side routing by redirecting requests to index.html.  Additionally, update the Dockerfile to copy the new configuration  into the Nginx container.