### PR TITLE
feat: add useParam hook and integrate into RegisterRoute

### DIFF
--- a/frontend/src/hooks/useParam.ts
+++ b/frontend/src/hooks/useParam.ts
@@ -1,0 +1,7 @@
+import { useLocation } from "react-router";
+
+export function useParam(name: string): Maybe<string> {
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  return params.get(name) ?? undefined;
+}

--- a/frontend/src/routes/register.tsx
+++ b/frontend/src/routes/register.tsx
@@ -2,9 +2,12 @@ import { Link } from "react-router";
 import { useAuth } from "../hooks/useAuth";
 import { FormEvent, useState } from "react";
 import { AppwriteException } from "appwrite";
+import { useParam } from "../hooks/useParam";
 
 export function RegisterRoute() {
   const auth = useAuth();
+
+  const presentToken = useParam("token");
 
   const [err, setErr] = useState<string | undefined>(undefined);
   const [message, setMessage] = useState<string | undefined>(undefined);
@@ -12,7 +15,7 @@ export function RegisterRoute() {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [token, setToken] = useState("");
+  const [token, setToken] = useState(presentToken ?? "");
 
   function onSubmit(e: FormEvent) {
     e.preventDefault();


### PR DESCRIPTION
Implement the `useParam` hook to retrieve URL query parameters.  Integrate the hook into the `RegisterRoute` component to  initialize the token state with the value of the "token"  parameter from the URL, enhancing the registration flow.