### PR TITLE
feat(info): disable join/leave buttons after deadline

### DIFF
--- a/src/routes/info.tsx
+++ b/src/routes/info.tsx
@@ -5,7 +5,7 @@ import { RulesPageEn } from "../components/rulesPage.en";
 import { useLabels } from "../hooks/useLabels";
 import { usePreferences } from "../hooks/usePreferences";
 
-const DEADLINE = new Date(2025, 3, 20, 23, 59).getTime();
+const DEADLINE = new Date(2025, 3, 20, 23, 59, 59, 999).getTime();
 
 export function InfoRoute() {
   const now = Date.now();

--- a/src/routes/info.tsx
+++ b/src/routes/info.tsx
@@ -5,7 +5,12 @@ import { RulesPageEn } from "../components/rulesPage.en";
 import { useLabels } from "../hooks/useLabels";
 import { usePreferences } from "../hooks/usePreferences";
 
+const DEADLINE = new Date(2025, 3, 20, 23, 59).getTime();
+
 export function InfoRoute() {
+  const now = Date.now();
+  const deadlineDue = now > DEADLINE;
+
   const l = useLabels();
 
   const [getPref, setPref] = usePreferences();
@@ -23,22 +28,29 @@ export function InfoRoute() {
   const InfoPage = l("langId") == "en" ? InfoPageEn : InfoPageDe;
 
   const RulesPage = l("langId") == "en" ? RulesPageEn : RulesPageDe;
-  
+
   return (
     <section>
       <h3>{l("infoAndRegistration")}</h3>
       <form>
         {joined ? (
           <>
-            <button className="large" type="button" onClick={leave}>
-              {l("wantToLeave")}
-            </button>
+            {!deadlineDue && (
+              <button className="large" type="button" onClick={leave}>
+                {l("wantToLeave")}
+              </button>
+            )}
             <p>{l("participating")}</p>
           </>
         ) : (
-          <button className="large" type="button" onClick={join}>
-            {l("wantToJoin")}
-          </button>
+          <>
+            {!deadlineDue && (
+              <button className="large" type="button" onClick={join}>
+                {l("wantToJoin")}
+              </button>
+            )}
+            <p>{l("notParticipating")}</p>
+          </>
         )}
       </form>
       <p>

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -36,6 +36,7 @@ export type Labels =
   | "wantToJoin"
   | "wantToLeave"
   | "participating"
+  | "notParticipating"
   | "name"
   | "address"
   | "task"
@@ -95,6 +96,8 @@ const resources: Resources = {
       wantToJoin: "I Want To Join!",
       wantToLeave: "I Want To Leave!",
       participating: "You are paricipating in the 2025 Kneipolympics.",
+      notParticipating:
+        "You are not paricipating competitively in the 2025 Kneipolympics.",
       name: "Name",
       address: "Address",
       task: "Task",
@@ -147,6 +150,8 @@ const resources: Resources = {
       wantToJoin: "Ich will teilnehmen!",
       wantToLeave: "Ich will nicht teilnehmen!",
       participating: "Du nimmst an den Kneipolympics 2025 teil.",
+      notParticipating:
+        "Du nimmst nicht kompetetiv an den Kneipolympics 2025 teil.",
       name: "Name",
       address: "Adresse",
       task: "Aufgabe",


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#8YDjUKSid`](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/8YDjUKSid)

**feat(info): disable join/leave buttons after deadline**


Add a deadline check for April 20, 2025, 23:59 to InfoRoute and
conditionally hide the join and leave buttons once the deadline has passed.
Update translations to include a "notParticipating" label for clarity.

2 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [fix(info): extend deadline to include last millisecond](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/8YDjUKSid/commit/af4416ca-ee29-439f-a38b-4b838acf6815) | ⏳ |  |
| 1/2 | [feat(info): disable join/leave buttons after deadline](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/8YDjUKSid/commit/23475cd7-53ad-4ebd-9830-50ff1ee5157e) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/8YDjUKSid)_
<!-- GitButler Review Footer Boundary Bottom -->
