### PR TITLE
feat(contestantList): separate contestants into competitive groups

### DIFF
--- a/src/components/contestantList.tsx
+++ b/src/components/contestantList.tsx
@@ -23,7 +23,7 @@ export function ContestantList() {
 
   return (
     <section id="contestants">
-      <details>
+      <details open>
         <summary>Competitive</summary>
         <ul>
           {contestants.map((c) => {

--- a/src/components/contestantList.tsx
+++ b/src/components/contestantList.tsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from "react";
 import { useAdmin } from "../hooks/useAdmin";
 import { useDatabase } from "../hooks/useDatabase";
 import { useFunctions } from "../hooks/useFunctions";
+import { User } from "../contexts/admin";
 
 export function ContestantList() {
   const { assignToTeam } = useFunctions();
-  const { contestants } = useAdmin();
+  const { contestants, nonContestants } = useAdmin();
   const { getAll } = useDatabase();
 
   const [routes, setRoutes] = useState<ConcreteRoute[]>([]);
@@ -22,35 +23,56 @@ export function ContestantList() {
 
   return (
     <section id="contestants">
-      <ul>
-        {contestants.map((c) => {
-          const { firstName, lastName, route } = c.prefs;
-          return (
-            <li key={c.$id}>
-              {firstName} {lastName}
-              <div>
-                <label>
-                  Team:
-                  <select onChange={(e) => onChange(c.$id, e.target.value)}>
-                    <option value={"---"}>---</option>
-                    {routes.map((r) => {
-                      return (
-                        <option
-                          key={r.$id}
-                          value={r.$id}
-                          selected={r.$id === route}
-                        >
-                          {r.name}
-                        </option>
-                      );
-                    })}
-                  </select>
-                </label>
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+      <details>
+        <summary>Competitive</summary>
+        <ul>
+          {contestants.map((c) => {
+            return (
+              <ContestantCard user={c} routes={routes} onChange={onChange} />
+            );
+          })}
+        </ul>
+      </details>
+      <details>
+        <summary>Non Competitive</summary>
+        <ul>
+          {nonContestants.map((c) => {
+            return (
+              <ContestantCard user={c} routes={routes} onChange={onChange} />
+            );
+          })}
+        </ul>
+      </details>
     </section>
+  );
+}
+
+type ContestantCardProps = {
+  user: User;
+  routes: ConcreteRoute[];
+  onChange: (user: string, team: string) => void;
+};
+
+function ContestantCard({ user, routes, onChange }: ContestantCardProps) {
+  const { firstName, lastName, route } = user.prefs;
+  return (
+    <li key={user.$id}>
+      {firstName} {lastName}
+      <div>
+        <label>
+          Team:
+          <select onChange={(e) => onChange(user.$id, e.target.value)}>
+            <option value={"---"}>---</option>
+            {routes.map((r) => {
+              return (
+                <option key={r.$id} value={r.$id} selected={r.$id === route}>
+                  {r.name}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+      </div>
+    </li>
   );
 }

--- a/src/contexts/admin.tsx
+++ b/src/contexts/admin.tsx
@@ -8,7 +8,9 @@ export type User = Models.User<Models.Preferences & Prefs>;
 
 export type AdminContextType = {
   users: User[];
+  // TODO: this should probably be done in the component
   contestants: User[];
+  nonContestants: User[];
   isAdmin: boolean;
 };
 
@@ -22,6 +24,7 @@ export function AdminContextProvider({ children }: PropsWithChildren) {
 
   const [users, setUsers] = useState<User[]>([]);
   const [contestants, setContestants] = useState<User[]>([]);
+  const [nonContestants, setNonContestants] = useState<User[]>([]);
 
   useEffect(() => {
     if (can("getUsers", user?.labels)) {
@@ -33,17 +36,19 @@ export function AdminContextProvider({ children }: PropsWithChildren) {
   }, [functions, user]);
 
   useEffect(() => {
-    if (can("getContestants", user?.labels)) {
-      functions
-        .getContestants()
-        .then((response) => setContestants(response as User[]))
-        .catch(console.error);
-    }
-  }, [functions, user]);
+    const contestants = users.filter((user) => user.prefs["joined"] == "true");
+    const nonContestants = users.filter(
+      (user) => user.prefs["joined"] != "true",
+    );
+
+    setContestants(contestants);
+    setNonContestants(nonContestants);
+  }, [users]);
 
   const value: AdminContextType = {
     users,
     contestants,
+    nonContestants,
     isAdmin: user?.labels.includes("admin") ?? false,
   };
   return (


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#2JSQtbHZY`](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/2JSQtbHZY)

**feat(contestantList): separate contestants into competitive groups**


Refactor ContestantList to display competitive and non-competitive users
in separate collapsible sections. Introduce ContestantCard component to
encapsulate contestant rendering logic and improve code reuse.

Update admin context to track nonContestants alongside contestants by
filtering users based on their "joined" preference. This change enables
the UI to distinguish between competitive and non-competitive participants,
enhancing clarity and user experience.

2 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [feat(contestantList): expand Competitive section by default](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/2JSQtbHZY/commit/77055a90-30e7-4b47-9961-87456fbbbcfe) | ⏳ |  |
| 1/2 | [feat(contestantList): separate contestants into competitive groups](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/2JSQtbHZY/commit/2dc7729d-fb5f-4e5a-bb31-fcb41b924d66) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/h1ghbre4k3r/kneipolympics/reviews/2JSQtbHZY)_
<!-- GitButler Review Footer Boundary Bottom -->
